### PR TITLE
fix(recipe): comment out Firefox RPM removal & flatpak install

### DIFF
--- a/config/recipe.yml
+++ b/config/recipe.yml
@@ -23,8 +23,8 @@ modules:
       # - micro
       # - starship
     remove:
-      - firefox # default firefox removed in favor of flatpak
-      - firefox-langpacks # langpacks needs to also be removed to prevent dependency problems
+      # - firefox # default firefox removed in favor of flatpak
+      # - firefox-langpacks # langpacks needs to also be removed to prevent dependency problems
 
   - type: default-flatpaks
     notify: true # Send notification after install/uninstall is finished (true/false)

--- a/config/recipe.yml
+++ b/config/recipe.yml
@@ -23,8 +23,13 @@ modules:
       # - micro
       # - starship
     remove:
-      # - firefox # default firefox removed in favor of flatpak
-      # - firefox-langpacks # langpacks needs to also be removed to prevent dependency problems
+      # This is an example on how to remove RPMs properly
+      # "firefox" as main package, "firefox-langpacks" as a dependency
+      # not all packages need specific removal of a dependency,
+      # as that is usually handled automatically, this is just a rare case where that's needed.
+      #
+      # - firefox
+      # - firefox-langpacks
 
   - type: default-flatpaks
     notify: true # Send notification after install/uninstall is finished (true/false)
@@ -34,7 +39,7 @@ modules:
       # repo-name: flathub
       # repo-title: "Flathub (system-wide)" # Optional; this sets the remote's user-facing name in graphical frontends like GNOME Software
       install:
-        - org.mozilla.firefox
+        # - org.mozilla.firefox
         # - org.gnome.Loupe
         # - one.ablaze.floorp//lightning # This is an example of flatpak which has multiple branches in selection (flatpak//branch).
       # Flatpak runtimes are not supported (like org.winehq.Wine//stable-23.08),

--- a/config/recipe.yml
+++ b/config/recipe.yml
@@ -25,8 +25,8 @@ modules:
     remove:
       # This is an example on how to remove RPMs properly
       # "firefox" as main package, "firefox-langpacks" as a dependency
-      # not all packages need specific removal of a dependency,
-      # as that is usually handled automatically, this is just a rare case where that's needed.
+      # not all packages need specific removal of a dependency, as that is usually handled automatically
+      # this is just a rare case where that's needed.
       #
       # - firefox
       # - firefox-langpacks

--- a/config/recipe.yml
+++ b/config/recipe.yml
@@ -23,13 +23,10 @@ modules:
       # - micro
       # - starship
     remove:
-      # This is an example on how to remove RPMs properly
-      # "firefox" as main package, "firefox-langpacks" as a dependency
-      # not all packages need specific removal of a dependency, as that is usually handled automatically
-      # this is just a rare case where that's needed.
-      #
+      # example: removing firefox (in favor of the flatpak)
+      # "firefox" is the main package, "firefox-langpacks" is a dependency
       # - firefox
-      # - firefox-langpacks
+      # - firefox-langpacks # also remove firefox dependency (not required for all packages, this is a special case)
 
   - type: default-flatpaks
     notify: true # Send notification after install/uninstall is finished (true/false)


### PR DESCRIPTION
Firefox RPM removal is an opinionated choice, which should be represented as an example of how to remove RPM package properly, not as a "rule".

Solves & closes:
https://github.com/blue-build/template/issues/16