### PR TITLE
exclude Dolphin .directory files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cosign.key
 cosign.private
 /Containerfile
+.directory


### PR DESCRIPTION
KDE Dolphin adds these files to every directory for specific configs