### PR TITLE
chore: Adjust build time to reflect uBlue changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: bluebuild
 on:
   schedule:
-    - cron: "00 17 * * *" # build at 17:00 UTC every day 
+    - cron: "00 06 * * *" # build at 06:00 UTC every day 
                           # (20 minutes after last ublue images start building)
   push:
     paths-ignore: # don't rebuild if only documentation has changed


### PR DESCRIPTION
Universal Blue images have new build schedules. The last image to build is Bluefin (39) at 05:41 UTC

Template's build time should be set to 06:00 UTC