### PR TITLE
Fix link for offline ISO generation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The `latest` tag will automatically point to the latest build. That build will s
 
 ## ISO
 
-If build on Fedora Atomic, you can generate an offline ISO with the instructions available [here](https://blue-build.org/learn/universal-blue/#fresh-install-from-an-iso). These ISOs cannot unfortunately be distributed on GitHub for free due to large sizes, so for public projects something else has to be used for hosting.
+If build on Fedora Atomic, you can generate an offline ISO with the instructions available [here](https://blue-build.org/how-to/generate-iso/#_top). These ISOs cannot unfortunately be distributed on GitHub for free due to large sizes, so for public projects something else has to be used for hosting.
 
 ## Verification
 


### PR DESCRIPTION
This link was taking people to the "Fresh Install from an ISO" page rather than the "How to build an ISO based on your custom image of Fedora Atomic" page in the docs.