### PR TITLE
chore(.gitignore): ISO and checksum files generated by CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 cosign.key
 cosign.private
 /Containerfile
+*.iso
+*.iso-CHECKSUM


### PR DESCRIPTION
I usually add these two entries to my .gitignore to prevent accidentally committing massive binary blobs generated by the 'bluebuild generate-iso' command.

This may or may not be a sane default to have in the template itself, depending on how many users have the same habits I do when generating offline install media.